### PR TITLE
Add simulation metrics for blackjack

### DIFF
--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -33,6 +33,9 @@ export type SimulatorResult = {
   hoursPlayed: number;
   riskOfRuin: number;
   timeElapsed: number;
+  expectedValuePerHour: number;
+  standardDeviationPerHour: number;
+  n0: number;
 };
 
 export type AugmentedSimulatorResult = SimulatorResult & {
@@ -68,6 +71,9 @@ export interface FormattedSimulatorResult extends FormattedResult {
   houseEdge: string;
   stdDeviation: string;
   timeElapsed: string;
+  expectedValuePerHour: string;
+  standardDeviationPerHour: string;
+  n0: string;
 }
 
 function getChipUnit(minimumBet: number): number {
@@ -294,6 +300,9 @@ export function mergeResults(results: SimulatorResult[]): SimulatorResult {
       handsPushed: 0,
       handsWon: 0,
       timeElapsed: 0,
+      expectedValuePerHour: 0,
+      standardDeviationPerHour: 0,
+      n0: 0,
     }
   );
 }
@@ -443,6 +452,10 @@ export default class Simulator {
     // TODO: Make RoR configurable.
     const riskOfRuin = 0.05;
 
+    const expectedValuePerHour = amountEarned / hoursPlayed;
+    const standardDeviationPerHour = Math.sqrt(bankrollVariance) * Math.sqrt(handsPerHour);
+    const n0 = bankrollVariance / (amountEarned / handsPlayed) ** 2;
+
     return {
       amountEarned,
       amountWagered,
@@ -455,6 +468,9 @@ export default class Simulator {
       hoursPlayed,
       riskOfRuin,
       timeElapsed: Date.now() - startTime,
+      expectedValuePerHour,
+      standardDeviationPerHour,
+      n0,
     };
   }
 }


### PR DESCRIPTION
Add calculations for expected value per hour, standard deviation per hour, and N-0 to the simulator.

* Add `expectedValuePerHour`, `standardDeviationPerHour`, and `n0` properties to `SimulatorResult` type.
* Initialize `expectedValuePerHour`, `standardDeviationPerHour`, and `n0` in the simulator result.
* Calculate `expectedValuePerHour`, `standardDeviationPerHour`, and `n0` in the `run` method.
* Return `expectedValuePerHour`, `standardDeviationPerHour`, and `n0` in the simulator result.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Harsha0912/blackjack-simulator?shareId=XXXX-XXXX-XXXX-XXXX).